### PR TITLE
Continuous Deployment for development branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,9 +70,8 @@ jobs:
       - run:
           name: Run Widget tests
           # creates test report (reports/tests.jsonl) and coverage report (coverage/lcov.info)
-          command: >-
-            flutter test --coverage --reporter json
-              << pipeline.parameters.flutter-run-args >>
+          command: |
+            flutter test --coverage --reporter json << pipeline.parameters.flutter-run-args >> \
               > reports/tests.jsonl
 
       #################### TEST RESULTS #######################
@@ -113,9 +112,9 @@ jobs:
           name: Run Integration tests
           # `flutter drive` does not support machine-readable reports
           # regarding coverage see also https://stackoverflow.com/questions/57933204/flutter-driver-test-coverage-report
-          command: >-
-            flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart
-              -d web-server --web-renderer html
+          command: |
+            flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart \
+              -d web-server --web-renderer html \
               << pipeline.parameters.flutter-run-args >>
 
   analyze:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Run Widget tests
           # creates test report (reports/tests.jsonl) and coverage report (coverage/lcov.info)
-          command: >
+          command: >-
             flutter test --coverage --reporter json
               << pipeline.parameters.flutter-run-args >>
               > reports/tests.jsonl
@@ -113,7 +113,7 @@ jobs:
           name: Run Integration tests
           # `flutter drive` does not support machine-readable reports
           # regarding coverage see also https://stackoverflow.com/questions/57933204/flutter-driver-test-coverage-report
-          command: >
+          command: >-
             flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart
               -d web-server --web-renderer html
               << pipeline.parameters.flutter-run-args >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,12 @@ workflows:
       - run-integration-tests
       - analyze
       - build-and-deploy:
+          context: GH-Pages-<< pipeline.git.branch >>
           filters:
             branches:
               only:
                 - main
+                - development
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,15 @@ parameters:
     description: Common arguments for flutter commands that execute code (run, build, test, drive)
     type: string
     # see https://yaml-multiline.info/ for multi-line strings in yaml
+    # the name of the backend url env variable depends on the git branch name, which may contain slashes
+    # therefore, apply the dark arts (nested command substitution) to replace special characters by "_" in git branch names
     default: >-
       --web-renderer html
       --dart-define=CI_PROVIDER=CircleCI
       --dart-define=GIT_URL=<< pipeline.project.git_url >>
       --dart-define=GIT_BRANCH=<< pipeline.git.branch >>
       --dart-define=COMMIT_HASH=<< pipeline.git.revision >>
-      --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
+      --dart-define=BACKEND_URL="$(VAR_NAME="$(echo "BACKEND_URL_<< pipeline.git.branch >>" | sed 's/[^A-Za-z0-9]/_/g')" ; echo ${!VAR_NAME:-$BACKEND_URL_development})"
 
 orbs:
   flutter: circleci/flutter@1.0.1
@@ -40,7 +42,6 @@ jobs:
       - flutter/install_pub
       - run:
           name: Build web
-          # TODO code duplication: extract common args into a pipeline var (if possible)
           command: flutter build web << pipeline.parameters.flutter-run-args >>
       - run:
           name: Compress Artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ workflows:
               only:
                 - main
                 - development
-                - feature/cd-for-dev
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,7 @@ jobs:
           # regarding coverage see also https://stackoverflow.com/questions/57933204/flutter-driver-test-coverage-report
           command: |
             flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart \
-              -d web-server --web-renderer html \
-              << pipeline.parameters.flutter-run-args >>
+              -d web-server << pipeline.parameters.flutter-run-args >>
 
   analyze:
     executor: cirrusci-flutter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
               --dart-define=GIT_URL=<< pipeline.project.git_url >> \
               --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
               --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}"
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
       - run:
           name: Compress Artifacts
           command: zip -r ../web.zip .
@@ -70,7 +70,7 @@ jobs:
               --dart-define=GIT_URL=<< pipeline.project.git_url >> \
               --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
               --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}" \
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}" \
                 > reports/tests.jsonl
 
       #################### TEST RESULTS #######################
@@ -118,7 +118,7 @@ jobs:
               --dart-define=GIT_URL=<< pipeline.project.git_url >> \
               --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
               --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}"
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
 
   analyze:
     executor: cirrusci-flutter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
       - store_artifacts:
           path: build/web.zip
 
-      - add_ssh_keys
       - run:
           name: Deploy to GitHub Pages
           command: bash -x .circleci/deploy-gh-pages.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
               only:
                 - main
                 - development
+                - feature/cd-for-dev
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,14 @@ jobs:
       - flutter/install_pub
       - run:
           name: Build web
+          # TODO code duplication: extract common args into a pipeline var (if possible)
           command: |
             flutter build web --web-renderer html \
               --dart-define=CI_PROVIDER=CircleCI \
               --dart-define=GIT_URL=<< pipeline.project.git_url >> \
               --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
               --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}"
       - run:
           name: Compress Artifacts
           command: zip -r ../web.zip .
@@ -62,7 +64,14 @@ jobs:
       - run:
           name: Run Widget tests
           # creates test report (reports/tests.jsonl) and coverage report (coverage/lcov.info)
-          command: flutter test --coverage --reporter json > reports/tests.jsonl
+          command: |
+            flutter test --coverage --reporter json \
+              --dart-define=CI_PROVIDER=CircleCI \
+              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
+              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
+              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}" \
+                > reports/tests.jsonl
 
       #################### TEST RESULTS #######################
       - store_artifacts:
@@ -102,7 +111,14 @@ jobs:
           name: Run Integration tests
           # `flutter drive` does not support machine-readable reports
           # regarding coverage see also https://stackoverflow.com/questions/57933204/flutter-driver-test-coverage-report
-          command: flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart -d web-server --web-renderer html
+          command: |
+            flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart \
+              -d web-server --web-renderer html \
+              --dart-define=CI_PROVIDER=CircleCI \
+              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
+              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
+              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
+              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_DEVELOPMENT}"
 
   analyze:
     executor: cirrusci-flutter
@@ -115,6 +131,7 @@ jobs:
       - run:
           name: Run static analysis
           # for now, do not treat infos and warnings as job failure
+          # note: analyze does not need (or accept) the compile-time args
           command: flutter analyze --write=reports/static_analysis.txt --no-fatal-infos --no-fatal-warnings
       - store_artifacts:
           path: reports/static_analysis.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ parameters:
     description: Common arguments for flutter commands that execute code (run, build, test, drive)
     type: string
     # see https://yaml-multiline.info/ for multi-line strings in yaml
+    # (note that circleci seems to ignore `>` and `>-` for `run:` and `command:` items)
     # the name of the backend url env variable depends on the git branch name, which may contain slashes
     # therefore, apply the dark arts (nested command substitution) to replace special characters by "_" in git branch names
     default: >-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ workflows:
               only:
                 - main
                 - development
+                - feature/cd-for-dev
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,17 @@ parameters:
   flutter-version:
     type: string
     default: "2.8.1"
+  flutter-run-args:
+    description: Common arguments for flutter commands that execute code (run, build, test, drive)
+    type: string
+    # see https://yaml-multiline.info/ for multi-line strings in yaml
+    default: >-
+      --web-renderer html
+      --dart-define=CI_PROVIDER=CircleCI
+      --dart-define=GIT_URL=<< pipeline.project.git_url >>
+      --dart-define=GIT_BRANCH=<< pipeline.git.branch >>
+      --dart-define=COMMIT_HASH=<< pipeline.git.revision >>
+      --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
 
 orbs:
   flutter: circleci/flutter@1.0.1
@@ -30,13 +41,7 @@ jobs:
       - run:
           name: Build web
           # TODO code duplication: extract common args into a pipeline var (if possible)
-          command: |
-            flutter build web --web-renderer html \
-              --dart-define=CI_PROVIDER=CircleCI \
-              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
-              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
-              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
+          command: flutter build web << pipeline.parameter.flutter-run-args >>
       - run:
           name: Compress Artifacts
           command: zip -r ../web.zip .
@@ -64,14 +69,10 @@ jobs:
       - run:
           name: Run Widget tests
           # creates test report (reports/tests.jsonl) and coverage report (coverage/lcov.info)
-          command: |
-            flutter test --coverage --reporter json \
-              --dart-define=CI_PROVIDER=CircleCI \
-              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
-              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
-              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}" \
-                > reports/tests.jsonl
+          command: >
+            flutter test --coverage --reporter json
+              << pipeline.parameter.flutter-run-args >>
+              > reports/tests.jsonl
 
       #################### TEST RESULTS #######################
       - store_artifacts:
@@ -111,14 +112,10 @@ jobs:
           name: Run Integration tests
           # `flutter drive` does not support machine-readable reports
           # regarding coverage see also https://stackoverflow.com/questions/57933204/flutter-driver-test-coverage-report
-          command: |
-            flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart \
-              -d web-server --web-renderer html \
-              --dart-define=CI_PROVIDER=CircleCI \
-              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
-              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
-              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
-              --dart-define=BACKEND_URL="${BACKEND_URL_<< pipeline.git.branch >>:-$BACKEND_URL_development}"
+          command: >
+            flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart
+              -d web-server --web-renderer html
+              << pipeline.parameter.flutter-run-args >>
 
   analyze:
     executor: cirrusci-flutter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run:
           name: Build web
           # TODO code duplication: extract common args into a pipeline var (if possible)
-          command: flutter build web << pipeline.parameter.flutter-run-args >>
+          command: flutter build web << pipeline.parameters.flutter-run-args >>
       - run:
           name: Compress Artifacts
           command: zip -r ../web.zip .
@@ -71,7 +71,7 @@ jobs:
           # creates test report (reports/tests.jsonl) and coverage report (coverage/lcov.info)
           command: >
             flutter test --coverage --reporter json
-              << pipeline.parameter.flutter-run-args >>
+              << pipeline.parameters.flutter-run-args >>
               > reports/tests.jsonl
 
       #################### TEST RESULTS #######################
@@ -115,7 +115,7 @@ jobs:
           command: >
             flutter drive --driver=test_driver/integration_test.dart --target=integration_test/demo_test.dart
               -d web-server --web-renderer html
-              << pipeline.parameter.flutter-run-args >>
+              << pipeline.parameters.flutter-run-args >>
 
   analyze:
     executor: cirrusci-flutter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ workflows:
               only:
                 - main
                 - development
-                - feature/cd-for-dev
           requires:
             - run-widget-tests
             - run-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,12 @@ jobs:
       - flutter/install_pub
       - run:
           name: Build web
-          command: flutter build web --web-renderer html
+          command: |
+            flutter build web --web-renderer html \
+              --dart-define=CI_PROVIDER=CircleCI \
+              --dart-define=GIT_URL=<< pipeline.project.git_url >> \
+              --dart-define=GIT_BRANCH=<< pipeline.git.branch >> \
+              --dart-define=COMMIT_HASH=<< pipeline.git.revision >> \
       - run:
           name: Compress Artifacts
           command: zip -r ../web.zip .

--- a/.circleci/deploy-gh-pages.sh
+++ b/.circleci/deploy-gh-pages.sh
@@ -3,7 +3,7 @@
 
 # set default values (correspond to main) if not set
 # see https://stackoverflow.com/a/28085062/9335596 for syntax
-: "${GH_PAGES_USER:="AAU-ASE-GroupC-WS2021"}"
+: "${GH_PAGES_USER:="canteen-mgmt"}"
 : "${GH_PAGES_REPO:="$GH_PAGES_USER.github.io"}"
 : "${GH_PAGES_REPO_URL:="git@github.com:$GH_PAGES_USER/$GH_PAGES_REPO.git"}"
 : "${SOURCE_REPO:="AAU-ASE-GroupC-WS2021/canteenMgmtFrontend"}"

--- a/.circleci/deploy-gh-pages.sh
+++ b/.circleci/deploy-gh-pages.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 # based on deploy.sh from https://jasonthai.me/blog/2019/07/22/how-to-deploy-a-github-page-using-circleci-20-custom-jekyll-gems/
 
-ORG_NAME=AAU-ASE-GroupC-WS2021
-REPO_NAME=$ORG_NAME.github.io
+# set default values (correspond to main) if not set
+# see https://stackoverflow.com/a/28085062/9335596 for syntax
+: "${GH_PAGES_USER:="AAU-ASE-GroupC-WS2021"}"
+: "${GH_PAGES_REPO:="$GH_PAGES_USER.github.io"}"
+: "${GH_PAGES_REPO_URL:="git@github.com:$GH_PAGES_USER/$GH_PAGES_REPO.git"}"
+: "${SOURCE_REPO:="AAU-ASE-GroupC-WS2021/canteenMgmtFrontend"}"
 
-# commit message (copy commit title, link to original commit (+optional pr) in commit message body)
-COMMIT_TITLE="$(git log -1 --pretty=%s $CIRCLE_SHA1)"
-COMMIT_MESSAGE="built in CircleCI from $ORG_NAME/$REPO_NAME@$CIRCLE_SHA1"
-if [ -n "$CIRCLE_PR_NUMBER" ]
+# generate commit message (copy commit title, link to original commit (+optional pr) in commit message body)
+COMMIT_TITLE="$(git log -1 --pretty=%s)"
+COMMIT_HASH="$(git log -1 --pretty=%H)"
+
+if [ -n "$SOURCE_REPO" ]
 then
-  COMMIT_MESSAGE="$COMMIT_MESSAGE (see $ORG_NAME/$REPO_NAME#$CIRCLE_PR_NUMBER)"
+  COMMIT_MESSAGE="built in CircleCI from $SOURCE_REPO@$COMMIT_HASH"
+  if [ -n "$CIRCLE_PR_NUMBER" ]
+  then
+    COMMIT_MESSAGE="$COMMIT_MESSAGE (see $SOURCE_REPO#$CIRCLE_PR_NUMBER)"
+  fi
 fi
 
-# clone and empty repo, copy build over
-git clone git@github.com:$ORG_NAME/$REPO_NAME.git && \
-  cd $REPO_NAME && \
-  rm -rf ./* && \
+# clone and empty repo
+mkdir deploy_repo && cd "$_" && \
+  git clone $GH_PAGES_REPO_URL . && \
+  find . -maxdepth 1 -mindepth 1 ! -name '.git*' -exec rm -rf {} \; && \
   cp -r ../build/web/* .
 
 git config user.name "${GH_PAGES_NAME:-CircleCI}"
@@ -23,4 +32,4 @@ git config user.email "${GH_PAGES_EMAIL:-ci@circleci.com}"
 
 git add -fA
 git commit --allow-empty -m "$COMMIT_TITLE" -m "$COMMIT_MESSAGE"
-git push -f origin "${BRANCH:-master}"
+git push -f origin "${GH_PAGES_BRANCH:-master}"

--- a/.circleci/deploy-gh-pages.sh
+++ b/.circleci/deploy-gh-pages.sh
@@ -32,4 +32,4 @@ git config user.email "${GH_PAGES_EMAIL:-ci@circleci.com}"
 
 git add -fA
 git commit --allow-empty -m "$COMMIT_TITLE" -m "$COMMIT_MESSAGE"
-git push -f origin "${GH_PAGES_BRANCH:-master}"
+git push -f origin "${GH_PAGES_BRANCH:-main}"

--- a/.idea/runConfigurations/main__dev_deployment_.xml
+++ b/.idea/runConfigurations/main__dev_deployment_.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="main (dev deployment)" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--web-renderer html --dart-define=CI_PROVIDER=IntelliJ --dart-define=BACKEND_URL=&quot;https://aau-ase-ws21-canteen-app-dev.herokuapp.com/&quot;" />
+    <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/main__local_.xml
+++ b/.idea/runConfigurations/main__local_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="main.dart" type="FlutterRunConfigurationType" factoryName="Flutter">
+  <configuration default="false" name="main (local)" type="FlutterRunConfigurationType" factoryName="Flutter">
     <option name="additionalArgs" value="--web-renderer html --dart-define=CI_PROVIDER=IntelliJ" />
     <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
     <method v="2" />

--- a/.idea/runConfigurations/main__prod_deployment_.xml
+++ b/.idea/runConfigurations/main__prod_deployment_.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="main (prod deployment)" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--web-renderer html --dart-define=CI_PROVIDER=IntelliJ --dart-define=BACKEND_URL=&quot;https://aau-ase-ws21-canteen-app.herokuapp.com/&quot;" />
+    <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/main_dart.xml
+++ b/.idea/runConfigurations/main_dart.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="main.dart" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="--web-renderer html" />
+    <option name="additionalArgs" value="--web-renderer html --dart-define=CI_PROVIDER=IntelliJ" />
     <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
     <method v="2" />
   </configuration>

--- a/.idea/runConfigurations/server.xml
+++ b/.idea/runConfigurations/server.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="server" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="-d web-server --web-hostname 0.0.0.0 --web-port 5000 --web-renderer html" />
+    <option name="additionalArgs" value="-d web-server --web-hostname 0.0.0.0 --web-port 5000 --web-renderer html --dart-define=CI_PROVIDER=IntelliJ" />
     <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
     <method v="2" />
   </configuration>

--- a/.idea/runConfigurations/server.xml
+++ b/.idea/runConfigurations/server.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="server" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="-d web-server --web-hostname 0.0.0.0 --web-port 5000 --web-renderer html --dart-define=CI_PROVIDER=IntelliJ" />
+    <option name="additionalArgs" value="-d web-server --web-hostname 0.0.0.0 --web-port 5000 --web-renderer html --dart-define=CI_PROVIDER=IntelliJ --dart-define=BACKEND_URL=&quot;http://localhost:8080/&quot;" />
     <option name="filePath" value="$PROJECT_DIR$/lib/main.dart" />
     <method v="2" />
   </configuration>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Canteen Management Frontend](https://aau-ase-groupc-ws2021.github.io/)
+# [Canteen Management Frontend](https://canteen-mgmt.github.io/)
 
 [![CircleCI](https://circleci.com/gh/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend/tree/main.svg?style=shield)](https://circleci.com/gh/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend/tree/main)
 [![codecov](https://codecov.io/gh/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend/branch/main/graph/badge.svg?token=7XIIY93GYQ)](https://codecov.io/gh/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend)

--- a/integration_test/about_button_test.dart
+++ b/integration_test/about_button_test.dart
@@ -1,0 +1,36 @@
+import 'package:canteen_mgmt_frontend/main.dart' as app;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+const aboutItems = [
+  String.fromEnvironment('GIT_URL'),
+  String.fromEnvironment('GIT_BRANCH'),
+  String.fromEnvironment('COMMIT_HASH'),
+  String.fromEnvironment('CI_PROVIDER'),
+  String.fromEnvironment(
+    'BACKEND_URL',
+    defaultValue: 'http://localhost:8080/',
+  ),
+];
+
+// allow running this test by itself
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  test();
+}
+
+Future<void> test() async {
+  testWidgets("AboutButton test", (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.info), findsOneWidget);
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.info));
+    await tester.pumpAndSettle(); // wait until popup has opened
+
+    for (final item in aboutItems) {
+      expect(find.textContaining(item), findsWidgets);
+    }
+  });
+}

--- a/integration_test/demo_test.dart
+++ b/integration_test/demo_test.dart
@@ -1,12 +1,14 @@
+import 'package:canteen_mgmt_frontend/main.dart' as app;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import 'package:canteen_mgmt_frontend/main.dart' as app;
-
+// allow running this test by itself
 void main() {
-  // for `flutter drive`
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  test();
+}
 
+Future<void> test() async {
   testWidgets("demo test", (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();

--- a/integration_test/main_test.dart
+++ b/integration_test/main_test.dart
@@ -1,5 +1,6 @@
 import 'package:integration_test/integration_test.dart';
 
+import 'about_button_test.dart' as about_button;
 import 'demo_test.dart' as demo;
 
 void main() {
@@ -7,4 +8,5 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   demo.test();
+  about_button.test();
 }

--- a/integration_test/main_test.dart
+++ b/integration_test/main_test.dart
@@ -1,0 +1,10 @@
+import 'package:integration_test/integration_test.dart';
+
+import 'demo_test.dart' as demo;
+
+void main() {
+  // for `flutter drive`
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  demo.test();
+}

--- a/lib/models/dish.dart
+++ b/lib/models/dish.dart
@@ -21,11 +21,11 @@ class Dish {
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'name': name,
-    'price': price,
-    'type': type,
-  };
+        'id': id,
+        'name': name,
+        'price': price,
+        'type': type,
+      };
 
   @override
   String toString() {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,6 +1,7 @@
 import 'package:beamer/beamer.dart';
-import 'package:canteen_mgmt_frontend/widgets/about_button.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/about_button.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:beamer/beamer.dart';
+import 'package:canteen_mgmt_frontend/widgets/about_button.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -7,7 +8,10 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Canteen Management')),
+      appBar: AppBar(
+        title: const Text('Canteen Management'),
+        actions: const [AboutButton()],
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/services/abstract_service.dart
+++ b/lib/services/abstract_service.dart
@@ -24,7 +24,10 @@ abstract class AbstractService {
 
   /// Set X-XSRF-TOKEN header if cookie is set
   Map<String, String> getHeaders() {
-    var headers = {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"};
+    var headers = {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    };
     return headers;
   }
 }

--- a/lib/services/abstract_service.dart
+++ b/lib/services/abstract_service.dart
@@ -1,21 +1,15 @@
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 abstract class AbstractService {
-  final bool httpsEnabled =
-      !kDebugMode; // private property indicated by leading _
-  final String _restURL = kDebugMode
-      ? 'localhost:8080/'
-      : 'aau-ase-ws21-canteen-app.herokuapp.com/';
+  static const backendUrl = String.fromEnvironment(
+    'BACKEND_URL',
+    defaultValue: 'http://localhost:8080/',
+  );
 
   final _client = http.Client();
 
-  String _getProtocol() {
-    return httpsEnabled ? 'https' : 'http';
-  }
-
   Uri _getUri(String path) {
-    String uriString = _getProtocol() + "://" + _restURL + path;
+    String uriString = backendUrl + path;
 
     return Uri.parse(uriString);
   }

--- a/lib/services/dish_service.dart
+++ b/lib/services/dish_service.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import '../models/dish.dart';
 import 'abstract_service.dart';
 
-
 class DishService extends AbstractService {
   Future<List<Dish>> fetchDishes() async {
     final response = await get('dish');
@@ -23,7 +22,11 @@ class DishService extends AbstractService {
   }
 
   Future<Dish> createDish() async {
-    var body = json.encode(Dish(name: "Test", price: 9.99, type: "STARTER").toJson());
+    var body = json.encode(Dish(
+      name: "Test",
+      price: 9.99,
+      type: "STARTER",
+    ).toJson());
     final response = await post('dish', body);
 
     if (response.statusCode == 200) {

--- a/lib/widgets/about_button.dart
+++ b/lib/widgets/about_button.dart
@@ -8,6 +8,11 @@ class AboutButton extends StatelessWidget {
   static const commitHash = String.fromEnvironment('COMMIT_HASH');
   static const ciProvider = String.fromEnvironment('CI_PROVIDER');
 
+  static const backendUrl = String.fromEnvironment(
+    'BACKEND_URL',
+    defaultValue: 'http://localhost:8080/',
+  );
+
   @override
   Widget build(BuildContext context) {
     return IconButton(
@@ -22,7 +27,8 @@ class AboutButton extends StatelessWidget {
                   (ciProvider != '' ? ' by $ciProvider' : '') +
                   (gitUrl != '' ? ' from $gitUrl' : '') +
                   (gitBranch != '' ? ' (in $gitBranch)' : '') +
-                  (commitHash != '' ? ' at $commitHash' : ''),
+                  (commitHash != '' ? ' at $commitHash' : '') +
+                  '\nConnecting to API at $backendUrl',
             ),
           ],
         );

--- a/lib/widgets/about_button.dart
+++ b/lib/widgets/about_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class AboutButton extends StatelessWidget {
+  const AboutButton({Key? key}) : super(key: key);
+
+  static const gitUrl = String.fromEnvironment('GIT_URL');
+  static const gitBranch = String.fromEnvironment('GIT_BRANCH');
+  static const commitHash = String.fromEnvironment('COMMIT_HASH');
+  static const ciProvider = String.fromEnvironment('CI_PROVIDER');
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.info),
+      onPressed: () {
+        showAboutDialog(
+          context: context,
+          applicationName: 'Canteen Management',
+          children: const [
+            SelectableText(
+              'Built' +
+                  (ciProvider != '' ? ' by $ciProvider' : '') +
+                  (gitUrl != '' ? ' from $gitUrl' : '') +
+                  (gitBranch != '' ? ' (in $gitBranch)' : '') +
+                  (commitHash != '' ? ' at $commitHash' : ''),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/test/about_button_test.dart
+++ b/test/about_button_test.dart
@@ -1,0 +1,28 @@
+import 'package:canteen_mgmt_frontend/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const aboutItems = [
+  String.fromEnvironment('GIT_URL'),
+  String.fromEnvironment('GIT_BRANCH'),
+  String.fromEnvironment('COMMIT_HASH'),
+  String.fromEnvironment('CI_PROVIDER'),
+  String.fromEnvironment(
+    'BACKEND_URL',
+    defaultValue: 'http://localhost:8080/',
+  ),
+];
+
+void main() {
+  testWidgets('AboutButton test', (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp());
+
+    expect(find.byIcon(Icons.info), findsOneWidget);
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.info));
+    await tester.pumpAndSettle(); // wait until popup has opened
+
+    for (final item in aboutItems) {
+      expect(find.textContaining(item), findsWidgets);
+    }
+  });
+}

--- a/test/demo_test.dart
+++ b/test/demo_test.dart
@@ -5,10 +5,8 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:canteen_mgmt_frontend/main.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('demo test', (WidgetTester tester) async {


### PR DESCRIPTION
Enables CD to GitHub Pages for branch `development`. Includes improvements and fixes for the deployment script.
Also added an "about" button with (i) icon to the home screen that displays build information (including git branch and commit hash).

To verify that this is functional, see CircleCI pipeline runs simulated for [main](https://app.circleci.com/pipelines/github/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend/73/workflows/da4fa283-7498-40a9-9b58-96a66162c72a/jobs/262?invite=true#step-108-30) (deploys to [canteen-mgmt.github.io](https://canteen-mgmt.github.io/), see [repo](https://github.com/canteen-mgmt/canteen-mgmt.github.io)) and [development](https://app.circleci.com/pipelines/github/AAU-ASE-GroupC-WS2021/canteenMgmtFrontend/73/workflows/015e0d75-ca24-41c3-b183-d2b36422f5c8/jobs/258?invite=true#step-108-31) (deploys to [aau-ase-groupc-ws2021.github.io](https://aau-ase-groupc-ws2021.github.io/), see [repo](https://github.com/AAU-ASE-GroupC-WS2021/AAU-ASE-GroupC-WS2021.github.io)).

CircleCI setup: As [recommended by CircleCI](https://circleci.com/docs/2.0/gh-bb-integration/#controlling-access-via-a-machine-user) for complex deploy-key setups, a GitHub ["machine user"](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users) ([canteen-frontend-deploy-machine-user](https://github.com/canteen-frontend-deploy-machine-user)) was set up and added as collaborator to both GitHub Pages repos and the frontend repo (necessary for generating a deploy key used in the CircleCI frontend pipeline).