### PR TITLE
Remove # from flutter URL

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,9 @@ import 'services/dish_service.dart';
 void main() {
   GetIt.I.registerFactory<DishService>(() => DishService());
 
+  // remove .../#/... from url
+  Beamer.setPathUrlStrategy();
+
   runApp(MyApp());
 }
 


### PR DESCRIPTION
Flutter automatically inserts a `#` in the URL path.
For instance, `canteen-mgmt.github.io/#/dish`.
Apply the [fix from the beamer docs](https://pub.dev/packages/beamer#tips-and-common-issues) to remove it.