### PR TITLE
Re-add # in URL for GitHub Pages support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,9 +27,6 @@ Future<void> main() async {
     );
   }
 
-  // remove .../#/... from url
-  Beamer.setPathUrlStrategy();
-
   runApp(MyApp());
 }
 


### PR DESCRIPTION
Beamer provides an option to remove the `#` from the flutter url path.
But this introduces problems with github pages as these paths are actually handled by GitHub, not flutter.

For instance, the app may show the URL `https://canteen-mgmt.github.io/dish`, but when manually entering that URL or reloading the page, GitHub shows a 404.
This change resets the URL strategy (`https://canteen-mgmt.github.io/#/dish`) and re-introduces the `#`, but allows reloading and setting bookmarks.

Reverts #31, Un-fixes #21