### PR TITLE
Fix test results not processed if tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
           name: Generate JUnit XML report
           # see https://pub.dev/packages/junitreport
           command: flutter pub run junitreport:tojunit -i reports/tests.jsonl -o reports/tests.xml
+          when: always # especially when the tests fail
       - store_test_results:
           path: reports/tests.xml
       - store_artifacts:
@@ -106,6 +107,7 @@ jobs:
       - run:
           name: Set up GPG agent (for codecov signature verification)
           command: sudo apt-get -y update && sudo apt-get -y install gpg-agent
+          when: always
       - codecov/upload:
           file: coverage/lcov.info
 

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fails on purpose for testing circleci pipeline', (){
+    expect(1+1, equals(3), reason: 'fails on purpose');
+  });
+}


### PR DESCRIPTION
CircleCI marks pipelines as failed as soon as some step fails, and only executes steps that are supposed to also run on failed builds (like uploading test results). Unfortunately, tests results still need to be processed before uploading (convert from JSON list to JUnit XML format) which did not take place.